### PR TITLE
Add autoscaler priority expander

### DIFF
--- a/modules/extensions/autoscaler.tf
+++ b/modules/extensions/autoscaler.tf
@@ -20,7 +20,7 @@ locals {
   cluster_autoscaler_manifest_path = join("/", [local.yaml_manifest_path, "cluster_autoscaler.yaml"])
   cluster_autoscaler_defaults = {
     "cloudProvider"                              = "oci-oke",
-    "expander"                                   = "priority",
+    "extraArgs.expander"                         = "priority",
     "extraArgs.logtostderr"                      = "true",
     "extraArgs.v"                                = "4",
     "extraArgs.stderrthreshold"                  = "info",


### PR DESCRIPTION
First edition. A few things to discuss:
1. Do we need an `env.*.yaml` file to store the config (like env.tools.yaml)? The repo seems to only have one workspace `default`.
2. Wonder if I have the correct structure of the priorities defined in data. The YAML example is like:
```
data:
  priorities: |-
    10: 
      - .*t2\.large.*
      - .*t3\.large.*
    50: 
      - .*m4\.4xlarge.*
```
3. Verifying if I have the right regex for the priorities. 