### PR TITLE
Support stateless egress rules to allowed CIDRs

### DIFF
--- a/modules/network/nsg-controlplane.tf
+++ b/modules/network/nsg-controlplane.tf
@@ -82,6 +82,11 @@ locals {
         protocol = local.tcp_protocol, port = local.apiserver_port, source = allowed_cidr, source_type = local.rule_type_cidr
       }
     },
+    { for allowed_cidr in var.control_plane_allowed_cidrs :
+      "Allow TCP egress from kube-apiserver to ${allowed_cidr}" => {
+        protocol = local.tcp_protocol, port = local.apiserver_port, destination = allowed_cidr, destination_type = local.rule_type_cidr
+      }
+    },  // Allow egress to allowed CIDRs. This could be removed once https://github.com/oracle-terraform-modules/terraform-oci-oke/pull/1044/files#diff-22581a25add62ab66a7fea3ec452a13a8be27d31e3b467ae2b6c1230b9d77a10R158-R162 is merged.
     var.allow_rules_cp
   ) : {}
 }


### PR DESCRIPTION
To configure network security rules as stateless, each egress and ingress rule must have a corresponding counterpart to enable two-way communication.

The latest oci/terraform-oci-oke module only creates ingress rules that allow traffic from the allowed CIDRs to the Kubernetes API server. However, to support bidirectional communication, we also need corresponding egress rules that allow the API server to send responses back.

An open PR has been submitted to add these missing egress rules, but it is unclear when it will be merged.