### PR TITLE
Fix ARM image selection for A4 (AmpereOne) shapes

### DIFF
--- a/modules/workers/locals.tf
+++ b/modules/workers/locals.tf
@@ -119,7 +119,7 @@ locals {
           lookup(var.image_ids, "platform", null),
           lookup(var.image_ids, pool.image_type, null),
           length(regexall("GPU", pool.shape)) > 0 ? var.image_ids.gpu : var.image_ids.nongpu,
-          length(regexall("A[12]\\.", pool.shape)) > 0 ? var.image_ids.aarch64 : var.image_ids.x86_64,
+          length(regexall("A\\d+\\.", pool.shape)) > 0 ? var.image_ids.aarch64 : var.image_ids.x86_64,
           lookup(var.image_ids, format("%v %v", pool.os, split(".", pool.os_version)[0]), null),
         ]...)) : "${var.indexed_images[entry].sort_key}###${entry}"])), 0)), 1)
       )


### PR DESCRIPTION
Broaden the regex from A[12]\. to A\d+\. so that A4 and future ARM shapes are correctly matched to aarch64 images instead of x86_64.