### PR TITLE
Support bastion user data configuration

### DIFF
--- a/module-bastion.tf
+++ b/module-bastion.tf
@@ -62,6 +62,7 @@ module "bastion" {
   upgrade                        = var.bastion_upgrade
   user                           = var.bastion_user
   volume_kms_key_id              = var.bastion_volume_kms_key_id
+  cloud_init                     = var.bastion_cloud_init
 
   # Standard tags as defined if enabled for use, or freeform
   # User-provided tags are merged last and take precedence

--- a/modules/bastion/cloudinit.tf
+++ b/modules/bastion/cloudinit.tf
@@ -35,6 +35,16 @@ data "cloudinit_config" "bastion" {
     content  = jsonencode({ users = ["default", var.user] })
     filename = "10-user.yml"
   }
+
+  # Include custom cloud init MIME parts (inline string content only)
+  dynamic "part" {
+    for_each = var.cloud_init
+    iterator = part
+    content {
+      content      = part.value.content
+      content_type = part.value.content_type
+    }
+  }
 }
 
 resource "null_resource" "await_cloudinit" {

--- a/modules/bastion/compute.tf
+++ b/modules/bastion/compute.tf
@@ -79,7 +79,7 @@ resource "oci_core_instance" "bastion" {
     ignore_changes = [
       availability_domain,
       defined_tags, freeform_tags, display_name,
-      create_vnic_details, metadata, source_details,
+      create_vnic_details, source_details,
     ]
 
     precondition {

--- a/modules/bastion/variables.tf
+++ b/modules/bastion/variables.tf
@@ -28,6 +28,20 @@ variable "timezone" { type = string }
 variable "upgrade" { type = bool }
 variable "user" { type = string }
 variable "volume_kms_key_id" { type = string }
+variable "cloud_init" {
+  default     = []
+  description = "Optional extra text userdata merged after the default bastion cloud-init. Inline string content only; optional content_type defaults to text/x-shellscript."
+  type = list(object({
+    content      = string
+    content_type = optional(string, "text/x-shellscript")
+  }))
+  validation {
+    condition = alltrue([
+      for p in var.cloud_init : length(trimspace(p.content)) > 0
+    ])
+    error_message = "Each cloud_init entry must include non-empty content after trimming whitespace."
+  }
+}
 
 # Tags
 variable "defined_tags" { type = map(string) }

--- a/variables-bastion.tf
+++ b/variables-bastion.tf
@@ -95,6 +95,21 @@ variable "bastion_await_cloudinit" {
   type        = bool
 }
 
+variable "bastion_cloud_init" {
+  default     = []
+  description = "Optional extra text userdata merged after the default bastion cloud-init. Each entry uses inline string content only (required) and optional content_type; content_type defaults to text/x-shellscript for shell scripts."
+  type = list(object({
+    content      = string
+    content_type = optional(string, "text/x-shellscript")
+  }))
+  validation {
+    condition = alltrue([
+      for p in var.bastion_cloud_init : length(trimspace(p.content)) > 0
+    ])
+    error_message = "Each bastion_cloud_init entry must include non-empty content after trimming whitespace."
+  }
+}
+
 variable "bastion_volume_kms_key_id" {
   default     = null
   description = "The OCID of the OCI KMS key to assign as the master encryption key for the bastion host boot volume."


### PR DESCRIPTION
This allows us to configure userdata for OKE Bastion hosts so that we can apply vulnerability mitigations such as those for Copyfail or Dirtyfrag.

Plan using k8s-cluster-oci with NO userdata changes yet: https://faire.app.spacelift.io/stack/k8s-cluster-oci-ci04_ca-toronto-1/run/01KRC8DVM2PXMHF92MNTR7CRC4
Plan with both vulnerability mitigations applied: https://faire.app.spacelift.io/stack/k8s-cluster-oci-ci04_ca-toronto-1/run/01KRC8QCVWSV55E9KVPH8GSDBA - Nothing to do

**Concern**
The bastion host metadata is an ignored field in Terraform. I tested what happens if the ignore is removed which leads to a big diffs as seen below

Without the ignored the plans look like:
No userdata changes: https://faire.app.spacelift.io/stack/k8s-cluster-oci-ci04_ca-toronto-1/run/01KRC95K42BXSE3R3FSMZTGEH5
With userdata changes: https://faire.app.spacelift.io/stack/k8s-cluster-oci-ci04_ca-toronto-1/run/01KRC9QF6GCJ5YKJSQWX5NMP9H

So it seems more reasonable to keep the metadata ignore and replace bastion hosts using terraform tasks, though that does not scale very well. Thoughts?