### PR TITLE
Allow userdata changes to trigger operator host replacement

### DIFF
--- a/modules/operator/compute.tf
+++ b/modules/operator/compute.tf
@@ -89,7 +89,7 @@ resource "oci_core_instance" "operator" {
     ignore_changes = [
       availability_domain,
       defined_tags, freeform_tags, display_name,
-      create_vnic_details, metadata, source_details,
+      create_vnic_details, source_details,
     ]
 
     replace_triggered_by = [null_resource.operator_changed]


### PR DESCRIPTION
# Why

Operators already allow cloud_init userdata to be set https://github.com/Faire/terraform-oci-oke/blob/2cb639e379367c87d3db84225ef3bd99616c88b9/variables-operator.tf#L16 but would not replace the instance without removing this ignore.